### PR TITLE
Move date/time display to header corner

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -24,7 +24,7 @@
         }
         .system-stats {
             position: absolute;
-            top: 1rem;
+            top: 3rem;
             right: 2rem;
             background: rgba(0, 0, 0, 0.3);
             padding: 0.25rem 0.5rem;
@@ -34,9 +34,12 @@
             gap: 0.75rem;
         }
         .date-time {
-            margin-top: 0.25rem;
+            position: absolute;
+            top: 1rem;
+            right: 2rem;
             color: #ecf0f1;
             font-size: 1rem;
+            font-weight: bold;
         }
         .header h1 {
             color: #ecf0f1;


### PR DESCRIPTION
## Summary
- position date/time in the header's top-right corner and make it bold
- adjust system stats placement to sit beneath the new date/time display

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689342a6cf1c83279008d566aaf10924