### PR TITLE
Add login success bar chart and API

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -274,6 +274,20 @@
             height: 300px;
             margin-bottom: 2rem;
         }
+
+        #loginSuccessBar {
+            background: var(--bg-card);
+            margin: 2rem;
+            padding: 1.5rem;
+            border-radius: 8px;
+            overflow-x: auto;
+        }
+
+        #loginSuccessBarCanvas {
+            width: 100%;
+            height: 300px;
+            margin-bottom: 2rem;
+        }
     </style>
 </head>
 <body>
@@ -294,6 +308,10 @@
 
      <div id="loginFailuresBar">
          <canvas id="loginFailuresBarCanvas"></canvas>
+     </div>
+
+     <div id="loginSuccessBar">
+         <canvas id="loginSuccessBarCanvas"></canvas>
      </div>
 
      <div class="main-container">
@@ -389,6 +407,7 @@
              searchLogs();
              initSocket();
              loadLoginFailuresBar();
+             loadLoginSuccessBar();
 
          }
 
@@ -727,6 +746,84 @@
         })
         .catch(err => {
             console.error('Failed to load login failures', err);
+        });
+}
+
+        function loadLoginSuccessBar() {
+    fetch('/api/login_successes_by_client')
+        .then(res => res.json())
+        .then(data => {
+            if (data.length === 0) {
+                const canvas = document.getElementById('loginSuccessBarCanvas');
+                const ctx = canvas.getContext('2d');
+                ctx.clearRect(0, 0, canvas.width, canvas.height);
+                ctx.fillStyle = '#e0e0e0';
+                ctx.font = '16px sans-serif';
+                ctx.fillText('No login successes in the past day', 10, 25);
+                return;
+            }
+
+            data.sort((a, b) => b.count - a.count);
+            const labels = data.map(d => d.client_name);
+            const counts = data.map(d => d.count);
+            const ips = data.map(d => d.source_ip);
+
+            const canvas = document.getElementById('loginSuccessBarCanvas');
+            const container = document.getElementById('loginSuccessBar');
+            canvas.width = Math.max(data.length * 100, container.clientWidth);
+            canvas.height = 300;
+            const ctx = canvas.getContext('2d');
+            new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Login Successes',
+                        data: counts,
+                        backgroundColor: 'rgba(46, 204, 113, 0.6)',
+                        borderColor: 'rgba(39, 174, 96, 1)',
+                        borderWidth: 1,
+                        barThickness: 60
+                    }]
+                },
+                options: {
+                    responsive: false,
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            title: {
+                                display: true,
+                                text: 'Successes'
+                            }
+                        },
+                        x: {
+                            display: false
+                        }
+                    },
+                    plugins: {
+                        tooltip: {
+                            callbacks: {
+                                afterLabel: function(context) {
+                                    return 'IP: ' + ips[context.dataIndex];
+                                }
+                            }
+                        },
+                        datalabels: {
+                            anchor: 'center',
+                            align: 'center',
+                            rotation: -90,
+                            color: '#fff',
+                            font: { weight: 'bold' },
+                            formatter: function(value, ctx) {
+                                return ctx.chart.data.labels[ctx.dataIndex];
+                            }
+                        }
+                    }
+                }
+            });
+        })
+        .catch(err => {
+            console.error('Failed to load login successes', err);
         });
 }
 

--- a/tests/test_login_successes.py
+++ b/tests/test_login_successes.py
@@ -1,0 +1,47 @@
+import datetime
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_login_successes_by_client(tmp_path, monkeypatch):
+    pytest.importorskip("flask")
+    pytest.importorskip("flask_socketio")
+    db_file = tmp_path / 'logs.db'
+    monkeypatch.setenv('SYSLOG_DB_PATH', str(db_file))
+    monkeypatch.setenv('SYSLOG_AUTO_START', '0')
+
+    database = importlib.reload(importlib.import_module('database'))
+    dm = database.DatabaseManager(str(db_file), start_threads=False)
+    database.db_manager = dm
+
+    log_entry = {
+        'timestamp': datetime.datetime.utcnow().isoformat(),
+        'source_ip': '1.2.3.4',
+        'hostname': 'fw',
+        'client_name': 'clientA',
+        'program': 'auth',
+        'facility': 1,
+        'severity': 3,
+        'message': 'user login success',
+        'raw_message': 'user login success',
+        'logid': '1',
+        'log_type': 'event',
+        'log_subtype': 'auth',
+        'level': 'info',
+    }
+
+    dm.store_logs_batch([log_entry])
+
+    webapp = importlib.reload(importlib.import_module('webapp'))
+
+    with webapp.app.test_client() as client:
+        resp = client.get('/api/login_successes_by_client')
+        assert resp.status_code == 200
+        assert resp.get_json() == [
+            {'client_name': 'clientA', 'source_ip': '1.2.3.4', 'count': 1}
+        ]


### PR DESCRIPTION
## Summary
- add `/api/login_successes_by_client` endpoint for 24h login success counts
- display login success bar chart on dashboard
- test login success aggregation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68938cee9d388327b2c5837e67dd42b1