### PR TITLE
Handle full connection pool gracefully

### DIFF
--- a/database.py
+++ b/database.py
@@ -105,10 +105,10 @@ class DatabaseConnectionPool:
         finally:
             if conn:
                 try:
-                    # Return connection to pool or close if it was temporary
-                    if self.connections.qsize() < self.max_connections:
-                        self.connections.put(conn)
-                    else:
+                    # Return connection to pool or close if pool is full
+                    try:
+                        self.connections.put(conn, block=False)
+                    except queue.Full:
                         conn.close()
                 except Exception:
                     try:


### PR DESCRIPTION
## Summary
- Return connections to the pool without checking `qsize`
- Discard extra connections when the pool is full instead of blocking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899a57e27088327a3e085da985662ff