### PR TITLE
Handle missing ChartDataLabels plugin

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -392,7 +392,11 @@
     </div>
 
     <script>
-        Chart.register(ChartDataLabels);
+        try {
+            Chart.register(ChartDataLabels);
+        } catch (err) {
+            console.warn('ChartDataLabels plugin not found. Continuing without it.', err);
+        }
         let currentPage = 0;
         const logsPerPage = 50;
         let socket;


### PR DESCRIPTION
## Summary
- guard Chart.register against missing ChartDataLabels plugin and log warning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899aed967708327ad69dc7daee257ce