### PR TITLE
Default database fallback on D drive

### DIFF
--- a/database.py
+++ b/database.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 # Database configuration
 DB_PATH = Path(
-    os.environ.get("SYSLOG_DB_PATH", Path.home() / "SyslogData" / "firewall_logs.db")
+    os.environ.get("SYSLOG_DB_PATH", Path("D:/SyslogData/firewall_logs.db"))
 ).expanduser().resolve()
 LOG_RETENTION_DAYS = 40
 # Ensure database directory exists


### PR DESCRIPTION
## Summary
- default the database path to `D:/SyslogData/firewall_logs.db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899bd2f983c832782df7d152b8363f5