### PR TITLE
Add socket connection handlers

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -406,6 +406,12 @@
         // Initialize Socket.IO
         function initSocket() {
             socket = io('/logs');
+            socket.on('connect', function() {
+                console.info('Connected to log server');
+            });
+            socket.on('connect_error', function(err) {
+                console.warn('Socket connection error:', err);
+            });
             socket.on('new_log', function(log) {
                 if (liveUpdates) {
                     addLogToTop(log);


### PR DESCRIPTION
## Summary
- Handle socket `connect` and `connect_error` events in dashboard client
- Log connection status and errors for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c059cdd88327a0591b0ad7be3f4e