### PR TITLE
Use before_first_request for background metrics task

### DIFF
--- a/syslog_server.py
+++ b/syslog_server.py
@@ -9,13 +9,19 @@ from handler import start_syslog_server
 from webapp import app, socketio, _broadcast_performance_metrics
 from database import DB_PATH, LOG_RETENTION_DAYS
 
+# Flag to ensure the metrics broadcaster starts only once
+_metrics_task_started = False
+
 
 def create_app():
     """Initialize the Flask application and background tasks."""
 
-    @app.before_serving
+    @app.before_first_request
     def _start_background_tasks() -> None:
-        socketio.start_background_task(_broadcast_performance_metrics)
+        global _metrics_task_started
+        if not _metrics_task_started:
+            socketio.start_background_task(_broadcast_performance_metrics)
+            _metrics_task_started = True
 
     return app
 


### PR DESCRIPTION
## Summary
- Switch to `before_first_request` so older Flask versions can start background tasks
- Ensure performance metrics broadcaster launches only once

## Testing
- `pytest -q`
- `python syslog_server.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_6899c3113e988327a93f95b190644b99