### PR TITLE
Use before_first_request for background metrics

### DIFF
--- a/syslog_server.py
+++ b/syslog_server.py
@@ -10,12 +10,18 @@ from webapp import app, socketio, _broadcast_performance_metrics
 from database import DB_PATH, LOG_RETENTION_DAYS
 
 
+_metrics_task_started = False
+
+
 def create_app():
     """Initialize the Flask application and background tasks."""
 
-    @app.before_serving
+    @app.before_first_request
     def _start_background_tasks() -> None:
-        socketio.start_background_task(_broadcast_performance_metrics)
+        global _metrics_task_started
+        if not _metrics_task_started:
+            socketio.start_background_task(_broadcast_performance_metrics)
+            _metrics_task_started = True
 
     return app
 


### PR DESCRIPTION
## Summary
- Replace `@app.before_serving` with `@app.before_first_request` in `create_app`.
- Guard background metrics task with a flag so it launches only once.

## Testing
- `pytest`
- `python syslog_server.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install Flask==2.1.0 flask-socketio` *(fails: Could not find a version that satisfies the requirement Flask==2.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899c310141c83279fdfff1ab2e797fd