### PR TITLE
Read SECRET_KEY from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Python-based syslog server and web dashboard.
 - Flask-SocketIO
 - psutil (for cross-platform system metrics)
 
+## Environment Configuration
+
+The application reads settings from environment variables:
+
+- `SECRET_KEY`: secret key used by Flask for session management. Set this to a
+  strong random value in production. If not provided, the application falls back
+  to a development key.
+

--- a/webapp.py
+++ b/webapp.py
@@ -19,7 +19,8 @@ except Exception:  # pragma: no cover - optional dependency
     psutil = None
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'your-secret-key-change-this'
+# Read SECRET_KEY from environment with a development fallback
+app.config['SECRET_KEY'] = os.environ.get("SECRET_KEY", "dev-secret-key")
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode='threading')
 set_socketio(socketio)
 


### PR DESCRIPTION
## Summary
- Load Flask SECRET_KEY from the SECRET_KEY environment variable with a development fallback.
- Document required environment configuration for running the application.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c58980088327ae48c044b31c9cb9