### PR TITLE
Remove duplicate metrics task flag assignment

### DIFF
--- a/syslog_server.py
+++ b/syslog_server.py
@@ -12,10 +12,6 @@ from database import DB_PATH, LOG_RETENTION_DAYS
 # Flag to ensure the metrics broadcaster starts only once
 _metrics_task_started = False
 
-
-_metrics_task_started = False
-
-
 def create_app():
     """Initialize the Flask application and background tasks."""
 


### PR DESCRIPTION
## Summary
- remove redundant `_metrics_task_started` assignment so flag is only declared once before `create_app`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899c5898434832791a8ff61dbed6e40